### PR TITLE
Hpricot has gone.  Change to Nokogiri

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .bundle
 .DS_Store
 test/credentials.yml

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: .
   specs:
-    dreamy (0.5.7)
+    dreamy (0.5.8)
       nokogiri
       terminal-table (>= 1.0.5)
       uuid (>= 2.0.1)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     macaddr (1.7.2)
       systemu (~> 2.6.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,26 @@
 PATH
   remote: .
   specs:
-    dreamy (0.5.6)
-      hpricot (>= 0.7)
+    dreamy (0.5.7)
+      nokogiri
       terminal-table (>= 1.0.5)
       uuid (>= 2.0.1)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    hpricot (0.8.6)
-    macaddr (1.6.1)
-      systemu (~> 2.5.0)
+    macaddr (1.7.2)
+      systemu (~> 2.6.5)
+    nokogiri (1.15.6-x86_64-darwin)
+      racc (~> 1.4)
+    racc (1.8.0)
     rake (10.0.3)
     shoulda (2.11.3)
-    systemu (2.5.2)
-    terminal-table (1.4.5)
-    uuid (2.3.6)
+    systemu (2.6.5)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.5.0)
+    uuid (2.3.9)
       macaddr (~> 1.0)
 
 PLATFORMS
@@ -26,3 +30,6 @@ DEPENDENCIES
   dreamy!
   rake
   shoulda
+
+BUNDLED WITH
+   2.1.4

--- a/dreamy.gemspec
+++ b/dreamy.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency("hpricot", ">= 0.7")
+  gem.add_dependency("nokogiri")
   gem.add_dependency("terminal-table", [">= 1.0.5"])
   gem.add_dependency("uuid", [">= 2.0.1"])
 

--- a/lib/dreamy.rb
+++ b/lib/dreamy.rb
@@ -2,7 +2,7 @@ require 'uri'
 require 'net/https'
 require 'yaml'
 require 'rubygems'
-require 'hpricot'
+require 'nokogiri'
 require 'uuid'
 
 

--- a/lib/dreamy/base.rb
+++ b/lib/dreamy/base.rb
@@ -234,7 +234,7 @@ module Dreamy
     private
     
     def api_error?(doc)
-      raise ApiError, (doc/:data).innerHTML if (doc/:result).innerHTML == "error"
+      raise ApiError, (doc/:data).inner_html if (doc/:result).inner_html == "error"
     end
 
     def request(cmd,values={},use_post=false)
@@ -281,9 +281,9 @@ module Dreamy
       end
     end
 
-    # Converts a string response into an Hpricot xml element.
+    # Converts a string response into an Nokogiri xml element.
     def parse(response)
-      Hpricot.XML(response || '')
+      Nokogiri::XML(response || '')
     end
 
   end

--- a/lib/dreamy/version.rb
+++ b/lib/dreamy/version.rb
@@ -1,3 +1,3 @@
 module Dreamy
-  VERSION = "0.5.6"
+  VERSION = "0.5.8"
 end

--- a/test/announce_test.rb
+++ b/test/announce_test.rb
@@ -18,7 +18,7 @@ EOF
     end
 
     should "create a new list of announce lists from xml" do
-      l = Dreamy::AnnounceList.new_from_xml(Hpricot.XML(@xml))
+      l = Dreamy::AnnounceList.new_from_xml(Nokogiri::XML(@xml))
       assert_equal "Super Announce", l.name
       assert_equal 8675309, l.account_id
       assert_equal "anessalee.net", l.domain

--- a/test/dns_test.rb
+++ b/test/dns_test.rb
@@ -18,7 +18,7 @@ EOF
     end
 
     should "create a new DNS entry from xml" do
-      d = Dreamy::Dns.new_from_xml(Hpricot.XML(@xml))
+      d = Dreamy::Dns.new_from_xml(Nokogiri::XML(@xml))
       assert_equal 8675309, d.account_id
       assert_equal "", d.comment
       assert_equal 0, d.editable

--- a/test/domain_test.rb
+++ b/test/domain_test.rb
@@ -35,8 +35,8 @@ EOF
 </data>
 EOF
 
-    @d = Dreamy::Domain.new_from_xml(Hpricot.XML(@domain_xml))
-    @m = Dreamy::Domain.new_from_xml(Hpricot.XML(@mysql_xml))
+    @d = Dreamy::Domain.new_from_xml(Nokogiri::XML(@domain_xml))
+    @m = Dreamy::Domain.new_from_xml(Nokogiri::XML(@mysql_xml))
     end
 
     should "assign valid http domain from xml" do

--- a/test/mail_filter_test.rb
+++ b/test/mail_filter_test.rb
@@ -20,7 +20,7 @@ EOF
     end
 
     should "create a new user from xml" do
-      s = Dreamy::MailFilter.new_from_xml(Hpricot.XML(@xml))
+      s = Dreamy::MailFilter.new_from_xml(Nokogiri::XML(@xml))
       assert_equal 8675309, s.account_id
       assert_equal "test@anessalee.net", s.address
       assert_equal "from", s.filter_on

--- a/test/mysql_db_test.rb
+++ b/test/mysql_db_test.rb
@@ -16,7 +16,7 @@ EOF
     end
 
     should "create a new user from xml" do
-      db = Dreamy::MysqlDb.new_from_xml(Hpricot.XML(@xml))
+      db = Dreamy::MysqlDb.new_from_xml(Nokogiri::XML(@xml))
       assert_equal 8675309, db.account_id
       assert_equal "betterdb2435", db.name
       assert_equal "This one's better", db.description

--- a/test/mysql_host_test.rb
+++ b/test/mysql_host_test.rb
@@ -14,7 +14,7 @@ EOF
     end
 
     should "create a new user from xml" do
-      host = Dreamy::MysqlHost.new_from_xml(Hpricot.XML(@xml))
+      host = Dreamy::MysqlHost.new_from_xml(Nokogiri::XML(@xml))
       assert_equal 8675309, host.account_id
       assert_equal "mysql.site.dreamhosters.com", host.domain
       assert_equal "haass.tuna.dreamhost.com", host.home

--- a/test/mysql_user_test.rb
+++ b/test/mysql_user_test.rb
@@ -24,7 +24,7 @@ EOF
     end
 
     should "create a new user from xml" do
-      u = Dreamy::MysqlUser.new_from_xml(Hpricot.XML(@xml))
+      u = Dreamy::MysqlUser.new_from_xml(Nokogiri::XML(@xml))
       assert_equal 8675309, u.account_id
       assert_equal "betterdb2435", u.db
       assert_equal "haass.tuna.dreamhost.com", u.home

--- a/test/private_server_test.rb
+++ b/test/private_server_test.rb
@@ -16,7 +16,7 @@ EOF
     end
 
     should "create a new PS from xml" do
-      ps = Dreamy::PrivateServer.new_from_xml(Hpricot.XML(@xml))
+      ps = Dreamy::PrivateServer.new_from_xml(Nokogiri::XML(@xml))
       assert_equal 8675309, ps.account_id
       assert_equal "ps10034", ps.name
       assert_equal "web", ps.type
@@ -69,7 +69,7 @@ EOF
     end
     
     should "create settings hash from xml" do
-      settings = Dreamy::PrivateServer.settings_from_xml(Hpricot.XML(@xml))
+      settings = Dreamy::PrivateServer.settings_from_xml(Nokogiri::XML(@xml))
       assert_equal "1", settings["apache2_enabled"]
       assert_equal "", settings["comment"]
       assert_equal "0", settings["courier_enabled"]
@@ -96,7 +96,7 @@ EOF
     end
     
     should "create size hash from xml" do
-      size = Dreamy::PrivateServer.size_from_xml(Hpricot.XML(@xml))
+      size = Dreamy::PrivateServer.size_from_xml(Nokogiri::XML(@xml))
       assert_equal 2300, size["memory_mb"]
       assert_equal 0.00, size["monthly_cost"]
       assert_equal 0.0000, size["period_cost"]
@@ -117,7 +117,7 @@ EOF
     end
     
     should "create usage hash from xml" do
-      usage = Dreamy::PrivateServer.usage_from_xml(Hpricot.XML(@xml))
+      usage = Dreamy::PrivateServer.usage_from_xml(Nokogiri::XML(@xml))
       assert_equal 0.02, usage["load"]
       assert_equal 146, usage["memory_mb"]
       assert_equal "2009-05-02 17:26:44", usage["stamp"]
@@ -137,7 +137,7 @@ EOF
     end
     
     should "create pending server hash from xml" do
-      pending = Dreamy::PrivateServer.pending_from_xml(Hpricot.XML(@xml))
+      pending = Dreamy::PrivateServer.pending_from_xml(Nokogiri::XML(@xml))
       assert_equal "8675309", pending["account_id"]
       assert_equal "10.5.3.2", pending["ip"]
       assert_equal "2009-03-12 06:43:48", pending["stamp"]

--- a/test/subscriber_test.rb
+++ b/test/subscriber_test.rb
@@ -16,7 +16,7 @@ EOF
     end
 
     should "create a new user from xml" do
-      s = Dreamy::Subscriber.new_from_xml(Hpricot.XML(@xml))
+      s = Dreamy::Subscriber.new_from_xml(Nokogiri::XML(@xml))
       assert_equal "joe@schmoe.com", s.email
       assert_equal 1, s.confirmed
       assert_equal "2007-12-13 16:55:15", s.subscribe_date

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,4 @@
-require 'test/unit'
+#require 'test/unit'
 require 'rubygems'
 require 'shoulda'
 

--- a/test/user_test.rb
+++ b/test/user_test.rb
@@ -19,7 +19,7 @@ EOF
     end
 
     should "create a new user from xml" do
-      u = Dreamy::User.new_from_xml(Hpricot.XML(@xml))
+      u = Dreamy::User.new_from_xml(Nokogiri::XML(@xml))
       assert_equal 8675309, u.account_id
       assert_equal 123.04, u.disk_used_mb
       assert_equal "Joe Schmoe", u.gecos


### PR DESCRIPTION
With Ruby 3.3, Hpricot will no longer compile. As that gem has been retired, it's time to change to another XML parser.  Nokogiri seems to work, although I wasn't able to show the tests pass as I can't get the test suite working.